### PR TITLE
Update graph.js to include response headers in the body

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -190,10 +190,11 @@ Graph.prototype.get = function () {
       return;
     }
 
+    body = { ...JSON.parse(body), headers: res.headers };
     if (~res.headers['content-type'].indexOf('image')) {
       body = {
           image: true
-        , location: res.headers.location
+        , headers: res.headers
       };
     }
 
@@ -232,6 +233,7 @@ Graph.prototype.post = function() {
       return;
     }
 
+    body = { ...JSON.parse(body), headers: res.headers };
     self.end(body);
   })
   .on('error', (err) => {


### PR DESCRIPTION
We need the headers to properly throttle API responses from Facebook