### PR TITLE
catch JSON parsing errors in fbgraph

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -191,16 +191,16 @@ Graph.prototype.get = function () {
     }
 
     if (res.headers['content-type'] && ~res.headers['content-type'].indexOf('image')) {
-        body = {
-            image: true
-          , headers: res.headers
-        };
+      body = {
+        image: true
+      , headers: res.headers
+      };
     } else {
-        try {
-            body = { ...JSON.parse(body), headers: res.headers };
-        } catch (e) {
-            // parsing failed, pass raw body to end()
-        }
+      try {
+        body = { ...JSON.parse(body), headers: res.headers };
+      } catch (e) {
+        // parsing failed, pass raw body to end()
+      }
     }
 
     self.end(body);

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -239,9 +239,9 @@ Graph.prototype.post = function() {
     }
 
     try {
-        body = { ...JSON.parse(body), headers: res.headers };
+      body = { ...JSON.parse(body), headers: res.headers };
     } catch (e) {
-        // if parsing fails, we pass the raw body to end()
+      // if parsing fails, we pass the raw body to end()
     }
     self.end(body);
   })

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -190,12 +190,17 @@ Graph.prototype.get = function () {
       return;
     }
 
-    body = { ...JSON.parse(body), headers: res.headers };
-    if (~res.headers['content-type'].indexOf('image')) {
-      body = {
-          image: true
-        , headers: res.headers
-      };
+    if (res.headers['content-type'] && ~res.headers['content-type'].indexOf('image')) {
+        body = {
+            image: true
+          , headers: res.headers
+        };
+    } else {
+        try {
+            body = { ...JSON.parse(body), headers: res.headers };
+        } catch (e) {
+            // parsing failed, pass raw body to end()
+        }
     }
 
     self.end(body);
@@ -233,7 +238,11 @@ Graph.prototype.post = function() {
       return;
     }
 
-    body = { ...JSON.parse(body), headers: res.headers };
+    try {
+        body = { ...JSON.parse(body), headers: res.headers };
+    } catch (e) {
+        // if parsing fails, we pass the raw body to end()
+    }
     self.end(body);
   })
   .on('error', (err) => {

--- a/tests/graph.test.js
+++ b/tests/graph.test.js
@@ -279,30 +279,30 @@ vows.describe("graph.test").addBatch({
     }
   }
 }).addBatch({
-    "Hardening JSON Parsing": {
-        "When receiving an invalid JSON response": {
-            topic: function() {
-                var callback = this.callback;
-                var originalGet = request.get;
+  "Hardening JSON Parsing": {
+    "When receiving a non-JSON response": {
+      topic: function () {
+        var callback    = this.callback
+          , originalGet = request.get;
 
-                request.get = function(options, cb) {
-                    var res = { headers: { 'content-type': 'text/html' } };
-                    var body = '{"foo": bar}'; // Malformed JSON
-                    setImmediate(function() { cb(null, res, body); });
-                    return { on: function() { return this; } };
-                };
+        request.get = function (options, cb) {
+          var res  = { headers: { 'content-type': 'text/html' } }
+            , body = '{"foo": bar}'; // Malformed JSON
+          setImmediate(function () { cb(null, res, body); });
+          return { on: function () { return this; } };
+        };
 
-                graph.get('/me', function(err, res) {
-                    request.get = originalGet;
-                    callback(err, res);
-                });
-            },
-            "it should return an error instead of crashing": function(err, res) {
-                assert.isNotNull(err);
-                assert.equal(err.message, 'Error parsing json');
-            }
-        }
+        graph.get('/me', function (err, res) {
+          request.get = originalGet;
+          callback(err, res);
+        });
+      },
+      "it should return an error instead of crashing": function (err, res) {
+        assert.isNotNull(err);
+        assert.equal(err.message, 'Error parsing json');
+      }
     }
+  }
 }).addBatch({
   "When tests are over": {
     topic: function () {

--- a/tests/graph.test.js
+++ b/tests/graph.test.js
@@ -280,7 +280,7 @@ vows.describe("graph.test").addBatch({
   }
 }).addBatch({
     "Hardening JSON Parsing": {
-        "When receiving a non-JSON response": {
+        "When receiving an invalid JSON response": {
             topic: function() {
                 var callback = this.callback;
                 var originalGet = request.get;

--- a/tests/graph.test.js
+++ b/tests/graph.test.js
@@ -2,7 +2,8 @@ var graph    = require("../index")
   , FBConfig = require("./config").facebook
   , vows     = require("vows")
   , events   = require("events")
-  , assert   = require("assert");
+  , assert   = require("assert")
+  , request  = require("request");
 
 
 var testUser1      = {}
@@ -277,6 +278,31 @@ vows.describe("graph.test").addBatch({
       }
     }
   }
+}).addBatch({
+    "Hardening JSON Parsing": {
+        "When receiving a non-JSON response": {
+            topic: function() {
+                var callback = this.callback;
+                var originalGet = request.get;
+
+                request.get = function(options, cb) {
+                    var res = { headers: { 'content-type': 'text/html' } };
+                    var body = '{"foo": bar}'; // Malformed JSON
+                    setImmediate(function() { cb(null, res, body); });
+                    return { on: function() { return this; } };
+                };
+
+                graph.get('/me', function(err, res) {
+                    request.get = originalGet;
+                    callback(err, res);
+                });
+            },
+            "it should return an error instead of crashing": function(err, res) {
+                assert.isNotNull(err);
+                assert.equal(err.message, 'Error parsing json');
+            }
+        }
+    }
 }).addBatch({
   "When tests are over": {
     topic: function () {


### PR DESCRIPTION
This pull request improves the robustness of JSON parsing in the `Graph` class by adding error handling for malformed JSON responses. It also introduces new tests to verify that the application handles non-JSON responses gracefully instead of crashing.

Error handling improvements:

* Updated `Graph.prototype.get` and `Graph.prototype.post` in `lib/graph.js` to wrap JSON parsing in a `try/catch` block, ensuring that parsing errors do not crash the application and that raw bodies are passed to `end()` if parsing fails. [[1]](diffhunk://#diff-db5b32aaf8b3d568936a43882da4c8f618c9a337821d61957bdc687153b0a688L193-R203) [[2]](diffhunk://#diff-db5b32aaf8b3d568936a43882da4c8f618c9a337821d61957bdc687153b0a688R241-R245)

Testing enhancements:

* Added a new test batch in `tests/graph.test.js` to simulate receiving a malformed JSON response and verify that the error is handled correctly, returning an error instead of crashing.
* Imported the `request` module in `tests/graph.test.js` to enable mocking of HTTP requests for the new tests.